### PR TITLE
fix: remove unused IsScalarTower instances

### DIFF
--- a/LeanAPAP/Prereqs/Convolution/Compact.lean
+++ b/LeanAPAP/Prereqs/Convolution/Compact.lean
@@ -103,7 +103,7 @@ lemma smul_cconv [DistribSMul H R] [IsScalarTower H R R] [SMulCommClass H R R] (
   ext a
   simp only [Pi.smul_apply, smul_expect, cconv_apply, smul_mul_assoc]
 
-lemma cconv_smul [DistribSMul H R] [IsScalarTower H R R] [SMulCommClass H R R] (c : H)
+lemma cconv_smul [DistribSMul H R] [SMulCommClass H R R] (c : H)
     (f g : G → R) : f ∗ₙ c • g = c • (f ∗ₙ g) := by
   have := SMulCommClass.symm H R R
   ext a
@@ -265,7 +265,7 @@ lemma smul_cdconv [DistribSMul H R] [IsScalarTower H R R] [SMulCommClass H R R] 
   ext a
   simp only [Pi.smul_apply, smul_expect, cdconv_apply, smul_mul_assoc]
 
-lemma cdconv_smul [Star H] [DistribSMul H R] [IsScalarTower H R R] [SMulCommClass H R R]
+lemma cdconv_smul [Star H] [DistribSMul H R] [SMulCommClass H R R]
     [StarModule H R] (c : H) (f g : G → R) : f ○ₙ c • g = star c • (f ○ₙ g) := by
   have := SMulCommClass.symm H R R
   ext a


### PR DESCRIPTION
## Summary
Remove unused `IsScalarTower H R R` typeclass instances from `cconv_smul` and `cdconv_smul` lemmas.

## Details
The `unusedArguments` linter flagged the `IsScalarTower H R R` instances in both lemmas. The proofs don't actually use these instances - they only use `SMulCommClass`.

## Test plan
- ✅ Built `LeanAPAP.Prereqs.Convolution.Compact` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)