### PR TITLE
feat: fill in some prerequisites

### DIFF
--- a/APAP.lean
+++ b/APAP.lean
@@ -8,6 +8,7 @@ public import APAP.Mathlib.Analysis.Convolution
 public import APAP.Mathlib.Analysis.Normed.Ring.Basic
 public import APAP.Mathlib.Analysis.RCLike.Basic
 public import APAP.Mathlib.Analysis.SpecialFunctions.Complex.Circle
+public import APAP.Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
 public import APAP.Mathlib.Topology.Algebra.PontryaginDual
 public import APAP.Physics.AlmostPeriodicity
 public import APAP.Physics.DRC

--- a/APAP/FiniteField.lean
+++ b/APAP/FiniteField.lean
@@ -167,7 +167,7 @@ lemma ap_in_ff [DecidableEq G] (hq₃ : 3 ≤ q) (hq : q.Prime) (hα₀ : 0 < α
           |∑ x ∈ S, (μ (Set.toFinset V) ∗ μ A₁ ∗ μ A₂) x - ∑ x ∈ S, (μ A₁ ∗ μ A₂) x| ≤ ε := by
   classical
   let _ : MeasurableSpace G := ⊤
-  have : Fact (1 < q) := sorry
+  have : Fact (1 < q) := ⟨hq.one_lt⟩
   have : DiscreteMeasurableSpace G := ⟨fun _ ↦ trivial⟩
   have hA₁ : A₁.Nonempty := by simpa using hα₀.trans_le hαA₁
   have hA₂ : A₂.Nonempty := by simpa using hα₀.trans_le hαA₂

--- a/APAP/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
+++ b/APAP/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
@@ -1,0 +1,18 @@
+module
+
+public import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
+
+public section
+
+open ENNReal
+
+namespace MeasureTheory
+variable {𝕜 α : Type*} {m : MeasurableSpace α} {μ : Measure α} [NormedRing 𝕜]
+
+/-- Hölder's inequality. -/
+theorem eLpNorm_mul_le_mul_eLpNorm {p q r : ℝ≥0∞} {f g : α → 𝕜} (hf : AEStronglyMeasurable f μ)
+    (hg : AEStronglyMeasurable g μ) [HolderTriple p q r] :
+    eLpNorm (f * g) r μ ≤ eLpNorm f p μ * eLpNorm g q μ := by
+  simpa using eLpNorm_smul_le_mul_eLpNorm hg hf
+
+end MeasureTheory

--- a/APAP/Physics/AlmostPeriodicity.lean
+++ b/APAP/Physics/AlmostPeriodicity.lean
@@ -458,7 +458,7 @@ theorem linfty_almost_periodicity (ε : ℝ) (hε₀ : 0 < ε) (hε₁ : ε ≤ 
       = ‖∑ y, F y * μ (x +ᵥ -C) y‖ := by rw [this]
     _ ≤ ∑ y, ‖F y * μ (x +ᵥ -C) y‖ := norm_sum_le _ _
     _ = ‖F * μ (x +ᵥ -C)‖_[1] := by rw [MeasureTheory.dL1Norm_eq_sum_norm]; rfl
-    _ ≤ ‖F‖_[M] * ‖μ_[ℂ] (x +ᵥ -C)‖_[NNReal.conjExponent M] := MeasureTheory.dL1Norm_mul_le  _ _
+    _ ≤ ‖F‖_[M] * ‖μ_[ℂ] (x +ᵥ -C)‖_[NNReal.conjExponent M] := MeasureTheory.dLpNorm_mul_le  _ _
     _ ≤ ε / exp 1 * #B ^ (M : ℝ)⁻¹ * ‖μ_[ℂ] (x +ᵥ -C)‖_[NNReal.conjExponent M] := by
         gcongr
         simpa only [← ENNReal.coe_natCast, MeasureTheory.dLpNorm_indicate hM₀] using hT _ ht

--- a/APAP/Prereqs/FourierTransform/Convolution.lean
+++ b/APAP/Prereqs/FourierTransform/Convolution.lean
@@ -44,8 +44,33 @@ lemma cLpNorm_cconv_le_cLpNorm_cdconv (hn₀ : n ≠ 0) (hn : Even n) (f : G →
       _ = ‖𝔼 x, (∑ i, φ i - ∑ i, ψ i) x‖ := by simp [expect_eq_ite, apply_ite]
       _ = ‖𝔼 x, (∏ i, φ i x) * ∏ i, (ψ i) (-x)‖ := by simp [map_neg_eq_conj, AddChar.sub_apply]
 
+omit [AddCommGroup G] [DecidableEq G] in
+lemma cLpNorm_pow_eq_card_inv_mul_dLpNorm_pow (hn₀ : n ≠ 0) (f : G → ℂ) :
+    ‖f‖ₙ_[n] ^ n = (Fintype.card G : ℝ)⁻¹ * ‖f‖_[n] ^ n := by
+  rw [cLpNorm_pow_eq_expect_norm hn₀, dLpNorm_pow_eq_sum_norm hn₀]
+  simp [Fintype.expect_eq_sum_div_card, div_eq_mul_inv, mul_comm]
+
+omit [AddCommGroup G] [DecidableEq G] [DiscreteMeasurableSpace G] in
+lemma dLpNorm_card_inv_nnnat_smul (f : G → ℂ) :
+    ‖((Fintype.card G : ℚ≥0)⁻¹ • f)‖_[n] = (Fintype.card G : ℝ)⁻¹ * ‖f‖_[n] := by
+  rw [show ((Fintype.card G : ℚ≥0)⁻¹ • f) = ((Fintype.card G : ℂ)⁻¹ • f) by
+    ext x
+    simp [NNRat.smul_def]]
+  rw [dLpNorm_const_smul]
+  simp [norm_inv]
+
 lemma dLpNorm_conv_le_dLpNorm_dconv (hn₀ : n ≠ 0) (hn : Even n) (f : G → ℂ) :
-    ‖f ∗ f‖_[n] ≤ ‖f ○ f‖_[n] := sorry
+    ‖f ∗ f‖_[n] ≤ ‖f ○ f‖_[n] := by
+  refine le_of_pow_le_pow_left₀ hn₀ (by positivity) ?_
+  have h := pow_le_pow_left₀ (by positivity) (cLpNorm_cconv_le_cLpNorm_cdconv hn₀ hn f) n
+  rw [cconv_eq_smul_conv, cdconv_eq_smul_dconv] at h
+  have h' : (Fintype.card G : ℝ)⁻¹ * (((Fintype.card G : ℝ)⁻¹) ^ n * ‖f ∗ f‖_[n] ^ n) ≤
+      (Fintype.card G : ℝ)⁻¹ * (((Fintype.card G : ℝ)⁻¹) ^ n * ‖f ○ f‖_[n] ^ n) := by
+    simpa [cLpNorm_pow_eq_card_inv_mul_dLpNorm_pow hn₀, dLpNorm_card_inv_nnnat_smul, mul_pow,
+      mul_assoc, mul_left_comm, mul_comm] using h
+  have hpos : 0 < (Fintype.card G : ℝ)⁻¹ * ((Fintype.card G : ℝ)⁻¹) ^ n := by
+    positivity
+  nlinarith
 
 -- TODO: Can we unify with `cLpNorm_cconv_le_cLpNorm_cdconv`?
 lemma cLpNorm_cconv_le_cLpNorm_cdconv' (hn₀ : n ≠ 0) (hn : Even n) (f : G → ℝ) :

--- a/APAP/Prereqs/FourierTransform/Convolution.lean
+++ b/APAP/Prereqs/FourierTransform/Convolution.lean
@@ -51,7 +51,7 @@ lemma cLpNorm_pow_eq_card_inv_mul_dLpNorm_pow (hn₀ : n ≠ 0) (f : G → ℂ) 
   simp [Fintype.expect_eq_sum_div_card, div_eq_mul_inv, mul_comm]
 
 omit [AddCommGroup G] [DecidableEq G] [DiscreteMeasurableSpace G] in
-lemma dLpNorm_card_inv_nnnat_smul (f : G → ℂ) :
+lemma dLpNorm_card_inv_nnrat_smul (f : G → ℂ) :
     ‖((Fintype.card G : ℚ≥0)⁻¹ • f)‖_[n] = (Fintype.card G : ℝ)⁻¹ * ‖f‖_[n] := by
   rw [show ((Fintype.card G : ℚ≥0)⁻¹ • f) = ((Fintype.card G : ℂ)⁻¹ • f) by
     ext x
@@ -66,7 +66,7 @@ lemma dLpNorm_conv_le_dLpNorm_dconv (hn₀ : n ≠ 0) (hn : Even n) (f : G → �
   rw [cconv_eq_smul_conv, cdconv_eq_smul_dconv] at h
   have h' : (Fintype.card G : ℝ)⁻¹ * (((Fintype.card G : ℝ)⁻¹) ^ n * ‖f ∗ f‖_[n] ^ n) ≤
       (Fintype.card G : ℝ)⁻¹ * (((Fintype.card G : ℝ)⁻¹) ^ n * ‖f ○ f‖_[n] ^ n) := by
-    simpa [cLpNorm_pow_eq_card_inv_mul_dLpNorm_pow hn₀, dLpNorm_card_inv_nnnat_smul, mul_pow,
+    simpa [cLpNorm_pow_eq_card_inv_mul_dLpNorm_pow hn₀, dLpNorm_card_inv_nnrat_smul, mul_pow,
       mul_assoc, mul_left_comm, mul_comm] using h
   have hpos : 0 < (Fintype.card G : ℝ)⁻¹ * ((Fintype.card G : ℝ)⁻¹) ^ n := by
     positivity

--- a/APAP/Prereqs/FourierTransform/Convolution.lean
+++ b/APAP/Prereqs/FourierTransform/Convolution.lean
@@ -1,8 +1,7 @@
 module
 
 public import APAP.Prereqs.Convolution.Compact
-public import APAP.Prereqs.LpNorm.Compact
-public import APAP.Prereqs.LpNorm.Discrete.Defs
+public import APAP.Prereqs.LpNorm.Discrete.Basic
 
 import APAP.Prereqs.FourierTransform.Compact
 import Mathlib.MeasureTheory.Integral.Bochner.Basic
@@ -44,32 +43,16 @@ lemma cLpNorm_cconv_le_cLpNorm_cdconv (hn₀ : n ≠ 0) (hn : Even n) (f : G →
       _ = ‖𝔼 x, (∑ i, φ i - ∑ i, ψ i) x‖ := by simp [expect_eq_ite, apply_ite]
       _ = ‖𝔼 x, (∏ i, φ i x) * ∏ i, (ψ i) (-x)‖ := by simp [map_neg_eq_conj, AddChar.sub_apply]
 
-omit [AddCommGroup G] [DecidableEq G] in
-lemma cLpNorm_pow_eq_card_inv_mul_dLpNorm_pow (hn₀ : n ≠ 0) (f : G → ℂ) :
-    ‖f‖ₙ_[n] ^ n = (Fintype.card G : ℝ)⁻¹ * ‖f‖_[n] ^ n := by
-  rw [cLpNorm_pow_eq_expect_norm hn₀, dLpNorm_pow_eq_sum_norm hn₀]
-  simp [Fintype.expect_eq_sum_div_card, div_eq_mul_inv, mul_comm]
-
-omit [AddCommGroup G] [DecidableEq G] [DiscreteMeasurableSpace G] in
-lemma dLpNorm_card_inv_nnrat_smul (f : G → ℂ) :
-    ‖((Fintype.card G : ℚ≥0)⁻¹ • f)‖_[n] = (Fintype.card G : ℝ)⁻¹ * ‖f‖_[n] := by
-  rw [show ((Fintype.card G : ℚ≥0)⁻¹ • f) = ((Fintype.card G : ℂ)⁻¹ • f) by
-    ext x
-    simp [NNRat.smul_def]]
-  rw [dLpNorm_const_smul]
-  simp [norm_inv]
-
 lemma dLpNorm_conv_le_dLpNorm_dconv (hn₀ : n ≠ 0) (hn : Even n) (f : G → ℂ) :
     ‖f ∗ f‖_[n] ≤ ‖f ○ f‖_[n] := by
   refine le_of_pow_le_pow_left₀ hn₀ (by positivity) ?_
   have h := pow_le_pow_left₀ (by positivity) (cLpNorm_cconv_le_cLpNorm_cdconv hn₀ hn f) n
   rw [cconv_eq_smul_conv, cdconv_eq_smul_dconv] at h
-  have h' : (Fintype.card G : ℝ)⁻¹ * (((Fintype.card G : ℝ)⁻¹) ^ n * ‖f ∗ f‖_[n] ^ n) ≤
-      (Fintype.card G : ℝ)⁻¹ * (((Fintype.card G : ℝ)⁻¹) ^ n * ‖f ○ f‖_[n] ^ n) := by
-    simpa [cLpNorm_pow_eq_card_inv_mul_dLpNorm_pow hn₀, dLpNorm_card_inv_nnrat_smul, mul_pow,
+  have h' : (Fintype.card G : ℝ)⁻¹ * (Fintype.card G : ℝ)⁻¹ ^ n * ‖f ∗ f‖_[n] ^ n ≤
+      (Fintype.card G : ℝ)⁻¹ * (Fintype.card G : ℝ)⁻¹ ^ n * ‖f ○ f‖_[n] ^ n := by
+    simpa [cLpNorm_pow_eq_card_inv_mul_dLpNorm_pow hn₀, dLpNorm_nnqsmul, mul_pow,
       mul_assoc, mul_left_comm, mul_comm] using h
-  have hpos : 0 < (Fintype.card G : ℝ)⁻¹ * ((Fintype.card G : ℝ)⁻¹) ^ n := by
-    positivity
+  have hpos : 0 < (Fintype.card G : ℝ)⁻¹ * (Fintype.card G : ℝ)⁻¹ ^ n := by positivity
   nlinarith
 
 -- TODO: Can we unify with `cLpNorm_cconv_le_cLpNorm_cdconv`?

--- a/APAP/Prereqs/Inner/Hoelder/Compact.lean
+++ b/APAP/Prereqs/Inner/Hoelder/Compact.lean
@@ -90,7 +90,7 @@ lemma cL1Norm_mul_of_nonneg (hf : 0 ≤ f) (hg : 0 ≤ g) : ‖f * g‖ₙ_[1] =
   convert cL1Norm_mul f g using 2 <;> ext a <;> refine (norm_of_nonneg ?_).symm; exacts [hf _, hg _]
 
 /-- **Hölder's inequality**, binary case. -/
-lemma wInner_cWeight_le_cLpNorm_mul_cLpNorm (p q : ℝ≥0∞) [hpq : p.HolderConjugate q] :
+lemma wInner_cWeight_le_cLpNorm_mul_cLpNorm (p q : ℝ≥0∞) [p.HolderConjugate q] :
     ⟪f, g⟫ₙ_[ℝ] ≤ ‖f‖ₙ_[p] * ‖g‖ₙ_[q] := by
   -- Step 1: `⟪f, g⟫ₙ_[ℝ] ≤ ⟪|f|, |g|⟫ₙ_[ℝ]` (dominate by absolute value)
   have h_abs : ⟪f, g⟫ₙ_[ℝ] ≤ ⟪fun i ↦ |f i|, fun i ↦ |g i|⟫ₙ_[ℝ] := by

--- a/APAP/Prereqs/Inner/Hoelder/Compact.lean
+++ b/APAP/Prereqs/Inner/Hoelder/Compact.lean
@@ -154,9 +154,10 @@ lemma cLpNorm_prod_le {ι : Type*} {s : Finset ι} (hs : s.Nonempty) {p : ι →
   | cons i s hi hs ih =>
   simp_rw [prod_cons]
   rw [sum_cons, ← inv_inv (∑ _ ∈ _, _)] at hpq
-  have : ENNReal.HolderTriple (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹ q := ⟨by
-    simpa [ENNReal.coe_inv (by simpa [hp] :
-      (∑ j ∈ s, (p j)⁻¹ : ℝ≥0) ≠ 0), ENNReal.coe_inv, hp] using hpq⟩
+  have : ENNReal.HolderTriple (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹ q := by
+    have : (∑ j ∈ s, (p j)⁻¹ : ℝ≥0) ≠ 0 := by simpa [hp]
+    constructor
+    simpa [ENNReal.coe_inv, *] using hpq
   grw [cLpNorm_mul_le (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹ , ih]
   · rw [← ENNReal.coe_inv, inv_inv]
     · push_cast

--- a/APAP/Prereqs/Inner/Hoelder/Compact.lean
+++ b/APAP/Prereqs/Inner/Hoelder/Compact.lean
@@ -4,6 +4,8 @@ public import APAP.Prereqs.LpNorm.Compact
 public import Mathlib.Analysis.RCLike.Inner
 
 import APAP.Prereqs.Inner.Hoelder.Discrete
+import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
+import Mathlib.MeasureTheory.Function.LpSeminorm.LpNorm
 import Mathlib.MeasureTheory.Integral.Bochner.Basic
 import Mathlib.Tactic.Positivity
 
@@ -46,6 +48,40 @@ end RCLike
 /-! ### Hölder inequality -/
 
 namespace MeasureTheory
+
+section Hoelder
+variable {α : Type*} {mα : MeasurableSpace α} [DiscreteMeasurableSpace α] [Fintype α] [RCLike 𝕜]
+  {p q r : ℝ≥0∞} {f g : α → 𝕜}
+
+omit [Fintype α]
+variable [Finite α]
+
+/-- **Hölder's inequality**, binary case. -/
+lemma cLpNorm_mul_le (p q : ℝ≥0∞) (_hr₀ : r ≠ 0) [hpqr : ENNReal.HolderTriple p q r] :
+    ‖f * g‖ₙ_[r] ≤ ‖f‖ₙ_[p] * ‖g‖ₙ_[q] := by
+  cases nonempty_fintype α
+  set μ := ProbabilityTheory.uniformOn (Set.univ : Set α) with hμ_def
+  have hμfin : IsFiniteMeasure μ := by rw [hμ_def]; infer_instance
+  have hm_r : MemLp (f * g) r μ := MemLp.of_discrete
+  have hm_p : MemLp f p μ := MemLp.of_discrete
+  have hm_q : MemLp g q μ := MemLp.of_discrete
+  have hbd : ∀ᵐ x ∂μ, ‖f x * g x‖₊ ≤ (1 : NNReal) * ‖f x‖₊ * ‖g x‖₊ :=
+    .of_forall fun x ↦ by rw [one_mul]; exact nnnorm_mul_le _ _
+  have key : eLpNorm (fun x ↦ f x * g x) r μ
+      ≤ ((1 : NNReal) : ℝ≥0∞) * eLpNorm f p μ * eLpNorm g q μ :=
+    eLpNorm_le_eLpNorm_mul_eLpNorm_of_nnnorm (p := p) (q := q) (r := r)
+      hm_p.aestronglyMeasurable hm_q.aestronglyMeasurable (· * ·) 1 hbd
+  change lpNorm _ _ μ ≤ lpNorm _ _ μ * lpNorm _ _ μ
+  rw [← toReal_eLpNorm hm_r.aestronglyMeasurable,
+      ← toReal_eLpNorm hm_p.aestronglyMeasurable,
+      ← toReal_eLpNorm hm_q.aestronglyMeasurable,
+      ← ENNReal.toReal_mul]
+  apply ENNReal.toReal_mono
+  · exact ENNReal.mul_ne_top hm_p.eLpNorm_ne_top hm_q.eLpNorm_ne_top
+  · simpa using key
+
+end Hoelder
+
 section Real
 variable {α : Type*} {mα : MeasurableSpace α} [DiscreteMeasurableSpace α] [Fintype α] {p q : ℝ≥0}
   {f g : α → ℝ}
@@ -54,22 +90,27 @@ lemma cL1Norm_mul_of_nonneg (hf : 0 ≤ f) (hg : 0 ≤ g) : ‖f * g‖ₙ_[1] =
   convert cL1Norm_mul f g using 2 <;> ext a <;> refine (norm_of_nonneg ?_).symm; exacts [hf _, hg _]
 
 /-- **Hölder's inequality**, binary case. -/
-lemma wInner_cWeight_le_cLpNorm_mul_cLpNorm (p q : ℝ≥0∞) [p.HolderConjugate q] :
+lemma wInner_cWeight_le_cLpNorm_mul_cLpNorm (p q : ℝ≥0∞) [hpq : p.HolderConjugate q] :
     ⟪f, g⟫ₙ_[ℝ] ≤ ‖f‖ₙ_[p] * ‖g‖ₙ_[q] := by
-  sorry
-  -- have hp := hpq.ne_zero
-  -- have hq := hpq.symm.ne_zero
-  -- norm_cast at hp hq
-  -- rw [wInner_cWeight_eq_expect, expect_eq_sum_div_card, cLpNorm_eq_expect_norm hp,
-  --   cLpNorm_eq_expect_norm hq, expect_eq_sum_div_card, expect_eq_sum_div_card,
-  --   NNReal.div_rpow, NNReal.div_rpow, ← NNReal.coe_mul, div_mul_div_comm, ← NNReal.rpow_add',
-  --   hpq.coe.inv_add_inv_conj, NNReal.rpow_one]
-  -- swap
-  -- · simp [hpq.coe.inv_add_inv_conj]
-  -- push_cast
-  -- gcongr
-  -- rw [← dLpNorm_eq_sum_norm hp, ← dLpNorm_eq_sum_norm hq, ← wInner_one_eq_sum]
-  -- exact wInner_one_le_dLpNorm_mul_dLpNorm hpq.coe_ennreal _ _
+  -- Step 1: `⟪f, g⟫ₙ_[ℝ] ≤ ⟪|f|, |g|⟫ₙ_[ℝ]` (dominate by absolute value)
+  have h_abs : ⟪f, g⟫ₙ_[ℝ] ≤ ⟪fun i ↦ |f i|, fun i ↦ |g i|⟫ₙ_[ℝ] := by
+    simp_rw [wInner_cWeight_eq_expect]
+    refine expect_le_expect fun i _ ↦ ?_
+    exact (le_abs_self _).trans (abs_mul _ _).le
+  refine h_abs.trans ?_
+  -- Step 2: Now both arguments are nonneg; the target becomes the Hölder inequality
+  -- `⟪|f|, |g|⟫ₙ_[ℝ] ≤ ‖|f|‖ₙ_[p] * ‖|g|‖ₙ_[q]` which we rewrite back to f, g using
+  -- `cLpNorm_abs` / `cLpNorm_fun_abs`.
+  have hfabs : ‖fun i ↦ |f i|‖ₙ_[p] = ‖f‖ₙ_[p] := by
+    simpa using cLpNorm_fun_abs (f := f) (p := p) .of_discrete
+  have hgabs : ‖fun i ↦ |g i|‖ₙ_[q] = ‖g‖ₙ_[q] := by
+    simpa using cLpNorm_fun_abs (f := g) (p := q) .of_discrete
+  rw [← hfabs, ← hgabs]
+  rw [show ⟪fun i ↦ |f i|, fun i ↦ |g i|⟫ₙ_[ℝ]
+        = ‖(fun i ↦ |f i|) * (fun i ↦ |g i|)‖ₙ_[1] from
+        (cL1Norm_mul_of_nonneg (f := fun i ↦ |f i|) (g := fun i ↦ |g i|)
+          (fun i ↦ abs_nonneg _) (fun i ↦ abs_nonneg _)).symm]
+  exact cLpNorm_mul_le p q one_ne_zero
 
 /-- **Hölder's inequality**, binary case. -/
 lemma abs_wInner_cWeight_le_dLpNorm_mul_dLpNorm (p q : ℝ≥0∞) [p.HolderConjugate q] :
@@ -98,32 +139,7 @@ lemma norm_wInner_cWeight_le_dLpNorm_mul_dLpNorm (p q : ℝ≥0∞) [p.HolderCon
     _ = ‖f‖ₙ_[p] * ‖g‖ₙ_[q] := by simp_rw [cLpNorm_norm .of_discrete]
 
 omit [Fintype α]
-
 variable [Finite α]
-
-set_option backward.isDefEq.respectTransparency false in
-/-- **Hölder's inequality**, binary case. -/
-lemma cLpNorm_mul_le (p q : ℝ≥0∞) (hr₀ : r ≠ 0) [hpqr : ENNReal.HolderTriple p q r] :
-    ‖f * g‖ₙ_[r] ≤ ‖f‖ₙ_[p] * ‖g‖ₙ_[q] := by
-  cases nonempty_fintype α
-  obtain rfl | p := p
-  · sorry
-  obtain rfl | q := q
-  · sorry
-  obtain rfl | r := r
-  · sorry
-  -- The following two come from `HolderTriple p q r`
-  have hp₀ : p ≠ 0 := sorry
-  have hq₀ : q ≠ 0 := sorry
-  simp only [ENNReal.some_eq_coe] at *
-  norm_cast at hr₀
-  have : (‖(f * g) ·‖ ^ (r : ℝ)) = (‖f ·‖ ^ (r : ℝ)) * (‖g ·‖ ^ (r : ℝ)) := by ext; simp [mul_rpow]
-  rw [cLpNorm_eq_expect_norm, rpow_inv_le_iff_of_pos, this, mul_rpow, cLpNorm_rpow', cLpNorm_rpow',
-    expect, smul_sum]
-  any_goals positivity
-  have := hpqr.holderConjugate_div_div _ _ _ (mod_cast hr₀) ENNReal.coe_ne_top
-  convert wInner_cWeight_le_cLpNorm_mul_cLpNorm (α := α) (p / r) (q / r) using 1
-  simp [wInner, cWeight, NNRat.smul_def, mul_comm]
 
 /-- **Hölder's inequality**, binary case. -/
 lemma cL1Norm_mul_le (p q : ℝ≥0∞) [hpq : ENNReal.HolderConjugate p q] :
@@ -138,7 +154,9 @@ lemma cLpNorm_prod_le {ι : Type*} {s : Finset ι} (hs : s.Nonempty) {p : ι →
   | cons i s hi hs ih =>
   simp_rw [prod_cons]
   rw [sum_cons, ← inv_inv (∑ _ ∈ _, _)] at hpq
-  have : ENNReal.HolderTriple (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹ q := ⟨sorry⟩
+  have : ENNReal.HolderTriple (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹ q := ⟨by
+    simpa [ENNReal.coe_inv (by simpa [hp] :
+      (∑ j ∈ s, (p j)⁻¹ : ℝ≥0) ≠ 0), ENNReal.coe_inv, hp] using hpq⟩
   grw [cLpNorm_mul_le (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹ , ih]
   · rw [← ENNReal.coe_inv, inv_inv]
     · push_cast

--- a/APAP/Prereqs/Inner/Hoelder/Discrete.lean
+++ b/APAP/Prereqs/Inner/Hoelder/Discrete.lean
@@ -3,7 +3,10 @@ module
 public import APAP.Prereqs.LpNorm.Discrete.Defs
 public import Mathlib.Analysis.RCLike.Inner
 
+import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
+import Mathlib.MeasureTheory.Function.LpSeminorm.LpNorm
 import Mathlib.MeasureTheory.Integral.Bochner.Basic
+import Mathlib.MeasureTheory.Measure.Count
 
 /-! # Inner product -/
 
@@ -45,10 +48,40 @@ lemma dL1Norm_mul_of_nonneg (hf : 0 ≤ f) (hg : 0 ≤ g) : ‖f * g‖_[1] = �
   convert dL1Norm_mul f g using 2 <;> ext a <;> refine (norm_of_nonneg ?_).symm; exacts [hf _, hg _]
 
 /-- **Hölder's inequality**, binary case. -/
-lemma wInner_one_le_dLpNorm_mul_dLpNorm (p q : ℝ≥0∞) [p.HolderConjugate q] :
+lemma wInner_one_le_dLpNorm_mul_dLpNorm (p q : ℝ≥0∞) [hpq : p.HolderConjugate q] :
     ⟪f, g⟫_[ℝ] ≤ ‖f‖_[p] * ‖g‖_[q] := by
-  sorry
-  -- simpa [wInner_one_eq_sum, dLpNorm_eq_sum_nnnorm, *] using inner_le_Lp_mul_Lq _ f g _
+  have hp0 : p ≠ 0 := ENNReal.HolderConjugate.ne_zero p q
+  have hq0 : q ≠ 0 := ENNReal.HolderConjugate.ne_zero q p
+  have hwInner : ⟪f, g⟫_[ℝ] = ∑ i, f i * g i := by
+    rw [wInner_one_eq_sum]
+    refine Finset.sum_congr rfl fun i _ ↦ ?_
+    change (inner ℝ (f i) (g i) : ℝ) = f i * g i
+    exact mul_comm (g i) (f i)
+  have hfg : ∀ i, f i * g i ≤ ‖f i‖ * ‖g i‖ := fun i =>
+    (le_abs_self _).trans_eq (by rw [abs_mul]; simp [Real.norm_eq_abs])
+  by_cases hpi : p = ∞
+  · have hq1 : q = 1 := (ENNReal.HolderConjugate.eq_top_iff_eq_one p q).mp hpi
+    subst hpi; subst hq1
+    rw [hwInner, dLinftyNorm_eq_iSup_norm, dL1Norm_eq_sum_norm, Finset.mul_sum]
+    exact Finset.sum_le_sum fun i _ ↦ (hfg i).trans
+      (mul_le_mul_of_nonneg_right
+        (le_ciSup (f := fun j ↦ ‖f j‖) (Finite.bddAbove_range _) i) (norm_nonneg _))
+  by_cases hqi : q = ∞
+  · have hp1 : p = 1 := (ENNReal.HolderConjugate.eq_top_iff_eq_one q p).mp hqi
+    subst hqi; subst hp1
+    rw [hwInner, dLinftyNorm_eq_iSup_norm, dL1Norm_eq_sum_norm, Finset.sum_mul]
+    exact Finset.sum_le_sum fun i _ ↦ (hfg i).trans
+      (mul_le_mul_of_nonneg_left
+        (le_ciSup (f := fun j ↦ ‖g j‖) (Finite.bddAbove_range _) i) (norm_nonneg _))
+  have hpr : 0 < p.toReal := ENNReal.toReal_pos hp0 hpi
+  have hqr : 0 < q.toReal := ENNReal.toReal_pos hq0 hqi
+  have hreal : Real.HolderConjugate p.toReal q.toReal := by
+    have := ENNReal.HolderTriple.toReal (p := p) (q := q) (r := 1) hpr hqr
+    simpa using this
+  rw [hwInner, dLpNorm_eq_sum_norm' hp0 hpi, dLpNorm_eq_sum_norm' hq0 hqi]
+  have key := Real.inner_le_Lp_mul_Lq Finset.univ f g hreal
+  simp only [one_div] at key
+  simpa [Real.norm_eq_abs] using key
 
 /-- **Hölder's inequality**, binary case. -/
 lemma abs_wInner_one_le_dLpNorm_mul_dLpNorm [p.HolderConjugate q] (f g : α → ℝ) :
@@ -78,29 +111,20 @@ omit [Fintype α]
 variable [Finite α]
 
 /-- **Hölder's inequality**, binary case. -/
-lemma dLpNorm_mul_le (p q : ℝ≥0∞) (hr₀ : r ≠ 0) [hpqr : ENNReal.HolderTriple p q r] :
+lemma dLpNorm_mul_le (p q : ℝ≥0∞) (_hr₀ : r ≠ 0) [hpqr : ENNReal.HolderTriple p q r] :
     ‖f * g‖_[r] ≤ ‖f‖_[p] * ‖g‖_[q] := by
   cases nonempty_fintype α
-  obtain rfl | p := p
-  · sorry
-  obtain rfl | q := q
-  · sorry
-  obtain rfl | r := r
-  · sorry
-  -- The following two come from `HolderTriple p q r`
-  have hp₀ : p ≠ 0 := sorry
-  have hq₀ : q ≠ 0 := sorry
-  simp only [ENNReal.some_eq_coe] at *
-  norm_cast at hr₀
-  have : (‖(f * g) ·‖ ^ (r : ℝ)) = (‖f ·‖ ^ (r : ℝ)) * (‖g ·‖ ^ (r : ℝ)) := by ext; simp [mul_rpow]
-  rw [dLpNorm_eq_dL1Norm_rpow, rpow_inv_le_iff_of_pos, this]
-  any_goals positivity
-  rw [dL1Norm_mul_of_nonneg, mul_rpow, dLpNorm_rpow', dLpNorm_rpow']
-  any_goals intro a; dsimp
-  any_goals positivity
-  any_goals simp
-  have := hpqr.holderConjugate_div_div _ _ _ (mod_cast hr₀) ENNReal.coe_ne_top
-  exact wInner_one_le_dLpNorm_mul_dLpNorm _ _
+  change lpNorm (f * g) r .count ≤ lpNorm f p .count * lpNorm g q .count
+  have hf : AEStronglyMeasurable f .count := .of_discrete
+  have hg : AEStronglyMeasurable g .count := .of_discrete
+  have hfg : AEStronglyMeasurable (f * g) .count := .of_discrete
+  rw [← toReal_eLpNorm hf, ← toReal_eLpNorm hg, ← toReal_eLpNorm hfg,
+      ← ENNReal.toReal_mul]
+  refine ENNReal.toReal_mono ?_ ?_
+  · exact (ENNReal.mul_lt_top eLpNorm_lt_top_of_finite eLpNorm_lt_top_of_finite).ne
+  · have hsmul : (f : α → 𝕜) • g = f * g := rfl
+    rw [← hsmul]
+    exact eLpNorm_smul_le_mul_eLpNorm hg hf
 
 /-- **Hölder's inequality**, binary case. -/
 lemma dL1Norm_mul_le (p q : ℝ≥0∞) [hpq : ENNReal.HolderConjugate p q] :
@@ -118,7 +142,9 @@ lemma dLpNorm_prod_le {ι : Type*} {s : Finset ι} (hs : s.Nonempty) {p : ι →
       simp [← hpq]
     simp_rw [prod_cons]
     rw [sum_cons, ← inv_inv (∑ _ ∈ _, _)] at hpq
-    have : ENNReal.HolderTriple (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹ q := ⟨sorry⟩
+    have : ENNReal.HolderTriple (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹ q := ⟨by
+      simpa [ENNReal.coe_inv (by simpa [hp] :
+        (∑ j ∈ s, (p j)⁻¹ : ℝ≥0) ≠ 0), ENNReal.coe_inv, hp] using hpq⟩
     grw [dLpNorm_mul_le (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹, ih hs]
     · rw [← ENNReal.coe_inv, inv_inv]
       · push_cast

--- a/APAP/Prereqs/Inner/Hoelder/Discrete.lean
+++ b/APAP/Prereqs/Inner/Hoelder/Discrete.lean
@@ -48,7 +48,7 @@ lemma dL1Norm_mul_of_nonneg (hf : 0 ≤ f) (hg : 0 ≤ g) : ‖f * g‖_[1] = �
 
 set_option backward.isDefEq.respectTransparency false in
 /-- **Hölder's inequality**, binary case. -/
-lemma wInner_one_le_dLpNorm_mul_dLpNorm (p q : ℝ≥0∞) [hpq : p.HolderConjugate q] :
+lemma wInner_one_le_dLpNorm_mul_dLpNorm (p q : ℝ≥0∞) [p.HolderConjugate q] :
     ⟪f, g⟫_[ℝ] ≤ ‖f‖_[p] * ‖g‖_[q] := by
   have hp0 : p ≠ 0 := ENNReal.HolderConjugate.ne_zero p q
   have hq0 : q ≠ 0 := ENNReal.HolderConjugate.ne_zero q p

--- a/APAP/Prereqs/Inner/Hoelder/Discrete.lean
+++ b/APAP/Prereqs/Inner/Hoelder/Discrete.lean
@@ -45,39 +45,31 @@ variable {α : Type*} {mα : MeasurableSpace α} [DiscreteMeasurableSpace α] [F
 lemma dL1Norm_mul_of_nonneg (hf : 0 ≤ f) (hg : 0 ≤ g) : ‖f * g‖_[1] = ⟪f, g⟫_[ℝ] := by
   convert dL1Norm_mul f g using 2 <;> ext a <;> refine (norm_of_nonneg ?_).symm; exacts [hf _, hg _]
 
+set_option backward.isDefEq.respectTransparency false in
 /-- **Hölder's inequality**, binary case. -/
 lemma wInner_one_le_dLpNorm_mul_dLpNorm (p q : ℝ≥0∞) [hpq : p.HolderConjugate q] :
     ⟪f, g⟫_[ℝ] ≤ ‖f‖_[p] * ‖g‖_[q] := by
   have hp0 : p ≠ 0 := ENNReal.HolderConjugate.ne_zero p q
   have hq0 : q ≠ 0 := ENNReal.HolderConjugate.ne_zero q p
-  have hwInner : ⟪f, g⟫_[ℝ] = ∑ i, f i * g i := by
-    rw [wInner_one_eq_sum]
-    refine Finset.sum_congr rfl fun i _ ↦ ?_
-    change (inner ℝ (f i) (g i) : ℝ) = f i * g i
-    exact mul_comm (g i) (f i)
-  have hfg : ∀ i, f i * g i ≤ ‖f i‖ * ‖g i‖ := fun i =>
+  have hwInner : ⟪f, g⟫_[ℝ] = ∑ i, f i * g i := by simp [wInner_one_eq_sum, mul_comm]
+  have hfg i : f i * g i ≤ ‖f i‖ * ‖g i‖ :=
     (le_abs_self _).trans_eq (by rw [abs_mul]; simp [Real.norm_eq_abs])
   obtain rfl | hpi := eq_or_ne p ∞
   · obtain rfl : q = 1 := (ENNReal.HolderConjugate.eq_top_iff_eq_one ∞ q).mp rfl
-    rw [hwInner, dLinftyNorm_eq_iSup_norm, dL1Norm_eq_sum_norm, Finset.mul_sum]
-    exact Finset.sum_le_sum fun i _ ↦ (hfg i).trans
-      (mul_le_mul_of_nonneg_right
-        (le_ciSup (f := fun j ↦ ‖f j‖) (Finite.bddAbove_range _) i) (norm_nonneg _))
+    simp only [hwInner, dL1Norm_eq_sum_norm, norm_eq_abs, dLinftyNorm_eq_iSup_norm, mul_sum]
+    gcongr ∑ _, ?_ with i
+    grw [le_abs_self (_ * _), abs_mul, ← le_ciSup (Finite.bddAbove_range _)]
   obtain rfl | hqi := eq_or_ne q ∞
   · obtain rfl : p = 1 := (ENNReal.HolderConjugate.eq_top_iff_eq_one ∞ p).mp rfl
-    rw [hwInner, dLinftyNorm_eq_iSup_norm, dL1Norm_eq_sum_norm, Finset.sum_mul]
-    exact Finset.sum_le_sum fun i _ ↦ (hfg i).trans
-      (mul_le_mul_of_nonneg_left
-        (le_ciSup (f := fun j ↦ ‖g j‖) (Finite.bddAbove_range _) i) (norm_nonneg _))
+    simp only [hwInner, dL1Norm_eq_sum_norm, norm_eq_abs, dLinftyNorm_eq_iSup_norm, sum_mul]
+    gcongr ∑ _, ?_ with i
+    grw [le_abs_self (_ * _), abs_mul, ← le_ciSup (Finite.bddAbove_range _)]
   have hpr : 0 < p.toReal := ENNReal.toReal_pos hp0 hpi
   have hqr : 0 < q.toReal := ENNReal.toReal_pos hq0 hqi
   have hreal : Real.HolderConjugate p.toReal q.toReal := by
-    have := ENNReal.HolderTriple.toReal (p := p) (q := q) (r := 1) hpr hqr
-    simpa using this
+    simpa using ENNReal.HolderTriple.toReal (p := p) (q := q) (r := 1) hpr hqr
   rw [hwInner, dLpNorm_eq_sum_norm' hp0 hpi, dLpNorm_eq_sum_norm' hq0 hqi]
-  have key := Real.inner_le_Lp_mul_Lq Finset.univ f g hreal
-  simp only [one_div] at key
-  simpa [Real.norm_eq_abs] using key
+  simpa using Real.inner_le_Lp_mul_Lq Finset.univ f g hreal
 
 /-- **Hölder's inequality**, binary case. -/
 lemma abs_wInner_one_le_dLpNorm_mul_dLpNorm [p.HolderConjugate q] (f g : α → ℝ) :

--- a/APAP/Prereqs/Inner/Hoelder/Discrete.lean
+++ b/APAP/Prereqs/Inner/Hoelder/Discrete.lean
@@ -3,10 +3,8 @@ module
 public import APAP.Prereqs.LpNorm.Discrete.Defs
 public import Mathlib.Analysis.RCLike.Inner
 
-import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
 import Mathlib.MeasureTheory.Function.LpSeminorm.LpNorm
 import Mathlib.MeasureTheory.Integral.Bochner.Basic
-import Mathlib.MeasureTheory.Measure.Count
 
 /-! # Inner product -/
 
@@ -59,16 +57,14 @@ lemma wInner_one_le_dLpNorm_mul_dLpNorm (p q : ℝ≥0∞) [hpq : p.HolderConjug
     exact mul_comm (g i) (f i)
   have hfg : ∀ i, f i * g i ≤ ‖f i‖ * ‖g i‖ := fun i =>
     (le_abs_self _).trans_eq (by rw [abs_mul]; simp [Real.norm_eq_abs])
-  by_cases hpi : p = ∞
-  · have hq1 : q = 1 := (ENNReal.HolderConjugate.eq_top_iff_eq_one p q).mp hpi
-    subst hpi; subst hq1
+  obtain rfl | hpi := eq_or_ne p ∞
+  · obtain rfl : q = 1 := (ENNReal.HolderConjugate.eq_top_iff_eq_one ∞ q).mp rfl
     rw [hwInner, dLinftyNorm_eq_iSup_norm, dL1Norm_eq_sum_norm, Finset.mul_sum]
     exact Finset.sum_le_sum fun i _ ↦ (hfg i).trans
       (mul_le_mul_of_nonneg_right
         (le_ciSup (f := fun j ↦ ‖f j‖) (Finite.bddAbove_range _) i) (norm_nonneg _))
-  by_cases hqi : q = ∞
-  · have hp1 : p = 1 := (ENNReal.HolderConjugate.eq_top_iff_eq_one q p).mp hqi
-    subst hqi; subst hp1
+  obtain rfl | hqi := eq_or_ne q ∞
+  · obtain rfl : p = 1 := (ENNReal.HolderConjugate.eq_top_iff_eq_one ∞ p).mp rfl
     rw [hwInner, dLinftyNorm_eq_iSup_norm, dL1Norm_eq_sum_norm, Finset.sum_mul]
     exact Finset.sum_le_sum fun i _ ↦ (hfg i).trans
       (mul_le_mul_of_nonneg_left

--- a/APAP/Prereqs/Inner/Hoelder/Discrete.lean
+++ b/APAP/Prereqs/Inner/Hoelder/Discrete.lean
@@ -1,5 +1,6 @@
 module
 
+public import APAP.Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
 public import APAP.Prereqs.LpNorm.Discrete.Defs
 public import Mathlib.Analysis.RCLike.Inner
 
@@ -99,24 +100,13 @@ omit [Fintype α]
 variable [Finite α]
 
 /-- **Hölder's inequality**, binary case. -/
-lemma dLpNorm_mul_le (p q : ℝ≥0∞) (_hr₀ : r ≠ 0) [hpqr : ENNReal.HolderTriple p q r] :
-    ‖f * g‖_[r] ≤ ‖f‖_[p] * ‖g‖_[q] := by
+lemma dLpNorm_mul_le (p q : ℝ≥0∞) [p.HolderTriple q r] : ‖f * g‖_[r] ≤ ‖f‖_[p] * ‖g‖_[q] := by
   cases nonempty_fintype α
   change lpNorm (f * g) r .count ≤ lpNorm f p .count * lpNorm g q .count
-  have hf : AEStronglyMeasurable f .count := .of_discrete
-  have hg : AEStronglyMeasurable g .count := .of_discrete
   have hfg : AEStronglyMeasurable (f * g) .count := .of_discrete
-  rw [← toReal_eLpNorm hf, ← toReal_eLpNorm hg, ← toReal_eLpNorm hfg,
-      ← ENNReal.toReal_mul]
-  refine ENNReal.toReal_mono ?_ ?_
-  · exact (ENNReal.mul_lt_top eLpNorm_lt_top_of_finite eLpNorm_lt_top_of_finite).ne
-  · have hsmul : (f : α → 𝕜) • g = f * g := rfl
-    rw [← hsmul]
-    exact eLpNorm_smul_le_mul_eLpNorm hg hf
-
-/-- **Hölder's inequality**, binary case. -/
-lemma dL1Norm_mul_le (p q : ℝ≥0∞) [hpq : ENNReal.HolderConjugate p q] :
-    ‖f * g‖_[1] ≤ ‖f‖_[p] * ‖g‖_[q] := dLpNorm_mul_le _ _ one_ne_zero
+  grw [← toReal_eLpNorm .of_discrete, ← toReal_eLpNorm .of_discrete, ← toReal_eLpNorm .of_discrete,
+    ← ENNReal.toReal_mul, ← eLpNorm_mul_le_mul_eLpNorm (r := r) .of_discrete .of_discrete]
+  exact (ENNReal.mul_lt_top eLpNorm_lt_top_of_finite eLpNorm_lt_top_of_finite).ne
 
 /-- **Hölder's inequality**, finitary case. -/
 lemma dLpNorm_prod_le {ι : Type*} {s : Finset ι} (hs : s.Nonempty) {p : ι → ℝ≥0} (hp : ∀ i, p i ≠ 0)
@@ -134,14 +124,11 @@ lemma dLpNorm_prod_le {ι : Type*} {s : Finset ι} (hs : s.Nonempty) {p : ι →
       simpa [ENNReal.coe_inv (by simpa [hp] :
         (∑ j ∈ s, (p j)⁻¹ : ℝ≥0) ≠ 0), ENNReal.coe_inv, hp] using hpq⟩
     grw [dLpNorm_mul_le (p i) ↑(∑ i ∈ s, (p i)⁻¹)⁻¹, ih hs]
-    · rw [← ENNReal.coe_inv, inv_inv]
-      · push_cast
-        congr! with i
-        exact (ENNReal.coe_inv <| hp _).symm
-      · simpa [hp]
-    · norm_cast
-      rintro rfl
-      simp [hp] at hpq
+    rw [← ENNReal.coe_inv, inv_inv]
+    · push_cast
+      congr! with i
+      exact (ENNReal.coe_inv <| hp _).symm
+    · simpa [hp]
 
 end Hoelder
 end MeasureTheory

--- a/APAP/Prereqs/LpNorm/Compact.lean
+++ b/APAP/Prereqs/LpNorm/Compact.lean
@@ -198,10 +198,9 @@ lemma cLpNorm_exponent_top_eq_essSup (f : α → E) : ‖f‖ₙ_[∞] = ⨆ i, 
 @[gcongr] lemma cLpNorm_mono_right (hpq : p ≤ q) : ‖f‖ₙ_[p] ≤ ‖f‖ₙ_[q] := by
   cases isEmpty_or_nonempty α
   · simp [cLpNorm]
-  rw [cLpNorm, cLpNorm, ← toReal_eLpNorm (MemLp.of_discrete (p := p)).aestronglyMeasurable,
-      ← toReal_eLpNorm (MemLp.of_discrete (p := q)).aestronglyMeasurable]
+  rw [cLpNorm, cLpNorm, ← toReal_eLpNorm .of_discrete, ← toReal_eLpNorm .of_discrete]
   exact ENNReal.toReal_mono (MemLp.of_discrete (p := q)).eLpNorm_ne_top
-    (eLpNorm_le_eLpNorm_of_exponent_le hpq (MemLp.of_discrete (p := p)).aestronglyMeasurable)
+    (eLpNorm_le_eLpNorm_of_exponent_le hpq .of_discrete)
 
 lemma cLpNorm_mono_real {g : α → ℝ} (h : ∀ x, ‖f x‖ ≤ g x) : ‖f‖ₙ_[p] ≤ ‖g‖ₙ_[p] :=
   lpNorm_mono_real .of_discrete h

--- a/APAP/Prereqs/LpNorm/Compact.lean
+++ b/APAP/Prereqs/LpNorm/Compact.lean
@@ -195,7 +195,13 @@ lemma cLpNorm_exponent_top_eq_essSup (f : α → E) : ‖f‖ₙ_[∞] = ⨆ i, 
 @[simp] lemma cLpNorm_pos (hp : p ≠ 0) : 0 < ‖f‖ₙ_[p] ↔ f ≠ 0 :=
   lpNorm_nonneg.lt_iff_ne'.trans (cLpNorm_eq_zero hp).not
 
-@[gcongr] lemma cLpNorm_mono_right (hpq : p ≤ q) : ‖f‖ₙ_[p] ≤ ‖f‖ₙ_[q] := sorry
+@[gcongr] lemma cLpNorm_mono_right (hpq : p ≤ q) : ‖f‖ₙ_[p] ≤ ‖f‖ₙ_[q] := by
+  cases isEmpty_or_nonempty α
+  · simp [cLpNorm]
+  rw [cLpNorm, cLpNorm, ← toReal_eLpNorm (MemLp.of_discrete (p := p)).aestronglyMeasurable,
+      ← toReal_eLpNorm (MemLp.of_discrete (p := q)).aestronglyMeasurable]
+  exact ENNReal.toReal_mono (MemLp.of_discrete (p := q)).eLpNorm_ne_top
+    (eLpNorm_le_eLpNorm_of_exponent_le hpq (MemLp.of_discrete (p := p)).aestronglyMeasurable)
 
 lemma cLpNorm_mono_real {g : α → ℝ} (h : ∀ x, ‖f x‖ ≤ g x) : ‖f‖ₙ_[p] ≤ ‖g‖ₙ_[p] :=
   lpNorm_mono_real .of_discrete h
@@ -276,18 +282,20 @@ variable {α : Type*} {mα : MeasurableSpace α} [DiscreteMeasurableSpace α] [F
 lemma cLpNorm_rpow (hp : p ≠ 0) (hq : q ≠ 0) (hf : 0 ≤ f) :
     ‖f ^ (q : ℝ)‖ₙ_[p] = ‖f‖ₙ_[p * q] ^ (q : ℝ) := by
   cases nonempty_fintype α
-  refine rpow_left_injOn (NNReal.coe_ne_zero.2 hp) (by dsimp; sorry) (by dsimp; sorry) ?_
+  refine rpow_left_injOn (NNReal.coe_ne_zero.2 hp) (by dsimp; positivity)
+    (by dsimp; positivity) ?_
   dsimp
-  rw [← rpow_mul sorry, ← mul_comm, ← ENNReal.coe_mul, ← NNReal.coe_mul,
+  rw [← rpow_mul (by positivity), ← mul_comm, ← ENNReal.coe_mul, ← NNReal.coe_mul,
     cLpNorm_rpow_eq_expect_norm hp, cLpNorm_rpow_eq_expect_norm (mul_ne_zero hq hp)]
   simp [abs_rpow_of_nonneg (hf _), rpow_mul]
 
 lemma cLpNorm_pow (hp : p ≠ 0) {q : ℕ} (hq : q ≠ 0) (f : α → ℂ) :
     ‖f ^ q‖ₙ_[p] = ‖f‖ₙ_[p * q] ^ q := by
   cases nonempty_fintype α
-  refine rpow_left_injOn (NNReal.coe_ne_zero.2 hp) (by dsimp; sorry) (by dsimp; sorry) ?_
+  refine rpow_left_injOn (NNReal.coe_ne_zero.2 hp) (by dsimp; positivity)
+    (by dsimp; positivity) ?_
   dsimp
-  rw [← rpow_natCast_mul sorry, ← mul_comm, ← ENNReal.coe_natCast, ← ENNReal.coe_mul,
+  rw [← rpow_natCast_mul (by positivity), ← mul_comm, ← ENNReal.coe_natCast, ← ENNReal.coe_mul,
     ← NNReal.coe_natCast, ← NNReal.coe_mul, cLpNorm_rpow_eq_expect_norm hp,
     cLpNorm_rpow_eq_expect_norm (by positivity)]
   simp [← rpow_natCast_mul]

--- a/APAP/Prereqs/LpNorm/Discrete/Basic.lean
+++ b/APAP/Prereqs/LpNorm/Discrete/Basic.lean
@@ -1,6 +1,7 @@
 module
 
 public import APAP.Prereqs.Function.Indicator.Defs
+public import APAP.Prereqs.LpNorm.Compact
 public import APAP.Prereqs.LpNorm.Discrete.Defs
 public import Mathlib.Algebra.Group.Translate
 public import Mathlib.Algebra.Star.Conjneg
@@ -19,6 +20,12 @@ open scoped BigOperators ComplexConjugate ENNReal NNReal translate mu
 
 namespace MeasureTheory
 variable {ι G 𝕜 E R : Type*} [Finite ι] {mι : MeasurableSpace ι} [DiscreteMeasurableSpace ι]
+
+omit [Finite ι] in
+lemma cLpNorm_pow_eq_card_inv_mul_dLpNorm_pow [Fintype ι] {n : ℕ} (hn₀ : n ≠ 0) (f : ι → ℂ) :
+    ‖f‖ₙ_[n] ^ n = (Fintype.card ι : ℝ)⁻¹ * ‖f‖_[n] ^ n := by
+  rw [cLpNorm_pow_eq_expect_norm hn₀, dLpNorm_pow_eq_sum_norm hn₀]
+  simp [Fintype.expect_eq_sum_div_card, div_eq_mul_inv, mul_comm]
 
 /-! ### Indicator -/
 

--- a/APAP/Prereqs/LpNorm/Discrete/Defs.lean
+++ b/APAP/Prereqs/LpNorm/Discrete/Defs.lean
@@ -90,6 +90,9 @@ lemma dLpNorm_fun_div_natCast [CharZero 𝕜] {n : ℕ} (hn : n ≠ 0) (f : α �
 
 end NormedField
 
+lemma dLpNorm_nnqsmul (q : ℚ≥0) (f : α → ℂ) : ‖q • f‖_[p] = q * ‖f‖_[p] := by
+  simpa [NNRat.smul_def] using dLpNorm_const_smul (q : ℂ) f
+
 section RCLike
 variable {p : ℝ≥0∞}
 

--- a/APAP/Prereqs/LpNorm/Discrete/Defs.lean
+++ b/APAP/Prereqs/LpNorm/Discrete/Defs.lean
@@ -273,18 +273,20 @@ variable {α : Type*} {mα : MeasurableSpace α} [DiscreteMeasurableSpace α] [F
 lemma dLpNorm_rpow (hp : p ≠ 0) (hq : q ≠ 0) (hf : 0 ≤ f) :
     ‖f ^ (q : ℝ)‖_[p] = ‖f‖_[p * q] ^ (q : ℝ) := by
   cases nonempty_fintype α
-  refine rpow_left_injOn (NNReal.coe_ne_zero.2 hp) (by dsimp; sorry) (by dsimp; sorry) ?_
+  refine rpow_left_injOn (NNReal.coe_ne_zero.2 hp) (by dsimp; positivity)
+    (by dsimp; positivity) ?_
   dsimp
-  rw [← rpow_mul sorry, ← mul_comm, ← ENNReal.coe_mul, ← NNReal.coe_mul,
+  rw [← rpow_mul (by positivity), ← mul_comm, ← ENNReal.coe_mul, ← NNReal.coe_mul,
     dLpNorm_rpow_eq_sum_norm hp, dLpNorm_rpow_eq_sum_norm (mul_ne_zero hq hp)]
   simp [abs_rpow_of_nonneg (hf _), ← rpow_mul]
 
 lemma dLpNorm_pow (hp : p ≠ 0) {q : ℕ} (hq : q ≠ 0) (f : α → ℂ) :
     ‖f ^ q‖_[p] = ‖f‖_[p * q] ^ q := by
   cases nonempty_fintype α
-  refine rpow_left_injOn (NNReal.coe_ne_zero.2 hp) (by dsimp; sorry) (by dsimp; sorry) ?_
+  refine rpow_left_injOn (NNReal.coe_ne_zero.2 hp) (by dsimp; positivity)
+    (by dsimp; positivity) ?_
   dsimp
-  rw [← rpow_natCast_mul sorry, ← mul_comm, ← ENNReal.coe_natCast, ← ENNReal.coe_mul,
+  rw [← rpow_natCast_mul (by positivity), ← mul_comm, ← ENNReal.coe_natCast, ← ENNReal.coe_mul,
     ← NNReal.coe_natCast, ← NNReal.coe_mul, dLpNorm_rpow_eq_sum_norm hp,
     dLpNorm_rpow_eq_sum_norm (by positivity)]
   simp [← rpow_natCast_mul]

--- a/APAP/Prereqs/LpNorm/Weighted.lean
+++ b/APAP/Prereqs/LpNorm/Weighted.lean
@@ -90,8 +90,10 @@ lemma wLpNorm_toNNReal_eq_sum_norm {p : ℝ} (hp : 0 < p) (w : α → ℝ≥0) (
 
 lemma wLpNorm_rpow_eq_sum_norm {p : ℝ≥0} (hp : p ≠ 0) (w : α → ℝ≥0) (f : α → E) :
     ‖f‖_[p, w] ^ (p : ℝ) = ∑ i, w i • ‖f i‖ ^ (p : ℝ) := by
-  simp [wLpNorm_eq_sum_norm, hp]
-  sorry
+  have hnn : 0 ≤ ∑ i, w i • ‖f i‖ ^ (p : ℝ) :=
+    Finset.sum_nonneg fun i _ => by rw [NNReal.smul_def]; positivity
+  rw [wLpNorm_eq_sum_norm (by exact_mod_cast hp) (by simp), ENNReal.coe_toReal,
+      Real.rpow_inv_rpow hnn (by exact_mod_cast hp)]
 
 lemma wLpNorm_pow_eq_sum_norm {p : ℕ} (hp : p ≠ 0) (w : α → ℝ≥0) (f : α → E) :
     ‖f‖_[p, w] ^ p = ∑ i, w i • ‖f i‖ ^ p := by
@@ -138,7 +140,8 @@ variable [DiscreteMeasurableSpace α] {p : ℝ≥0∞} {w : α → ℝ≥0} {f g
 
 @[simp]
 lemma wLpNorm_one [Fintype α] (hp₀ : p ≠ 0) (hp : p ≠ ∞) (w : α → ℝ≥0) :
-    ‖(1 : α → ℝ)‖_[p, w] = (∑ i, w i) ^ p.toReal⁻¹ := by simp [wLpNorm_eq_sum_norm hp₀ hp]; sorry
+    ‖(1 : α → ℝ)‖_[p, w] = (∑ i, w i) ^ p.toReal⁻¹ := by
+  simp [wLpNorm_eq_sum_norm hp₀ hp, NNReal.smul_def]
 
 lemma wLpNorm_mono [Finite α] (hf : 0 ≤ f) (hfg : f ≤ g) : ‖f‖_[p, w] ≤ ‖g‖_[p, w] :=
   lpNorm_mono_real .of_discrete (by simpa [abs_of_nonneg (hf _)])

--- a/APAP/Prereqs/LpNorm/Weighted.lean
+++ b/APAP/Prereqs/LpNorm/Weighted.lean
@@ -4,6 +4,7 @@ public import APAP.Prereqs.LpNorm.Discrete.Defs
 public import Mathlib.Algebra.Group.Translate
 
 import Mathlib.MeasureTheory.Function.LpSeminorm.LpNorm
+import Mathlib.Tactic.Positivity
 
 /-!
 # Lp norms
@@ -90,10 +91,10 @@ lemma wLpNorm_toNNReal_eq_sum_norm {p : ℝ} (hp : 0 < p) (w : α → ℝ≥0) (
 
 lemma wLpNorm_rpow_eq_sum_norm {p : ℝ≥0} (hp : p ≠ 0) (w : α → ℝ≥0) (f : α → E) :
     ‖f‖_[p, w] ^ (p : ℝ) = ∑ i, w i • ‖f i‖ ^ (p : ℝ) := by
-  have hnn : 0 ≤ ∑ i, w i • ‖f i‖ ^ (p : ℝ) :=
-    Finset.sum_nonneg fun i _ => by rw [NNReal.smul_def]; positivity
-  rw [wLpNorm_eq_sum_norm (by exact_mod_cast hp) (by simp), ENNReal.coe_toReal,
-      Real.rpow_inv_rpow hnn (by exact_mod_cast hp)]
+  rw [wLpNorm_eq_sum_norm (mod_cast hp) (by simp), ENNReal.coe_toReal,
+    Real.rpow_inv_rpow _ (mod_cast hp)]
+  simp only [NNReal.smul_def, smul_eq_mul]
+  positivity
 
 lemma wLpNorm_pow_eq_sum_norm {p : ℕ} (hp : p ≠ 0) (w : α → ℝ≥0) (f : α → E) :
     ‖f‖_[p, w] ^ p = ∑ i, w i • ‖f i‖ ^ p := by

--- a/APAP/Prereqs/NewMarcinkiewiczZygmund.lean
+++ b/APAP/Prereqs/NewMarcinkiewiczZygmund.lean
@@ -57,39 +57,15 @@ theorem marcinkiewicz_zygmund_symmetric (iIndepFun_X : iIndepFun X μ)
   have integrable_prod_norm_X I (hI : I ∈ A ×ˢ A ^^ m) :
     Integrable (fun ω ↦ ∏ k, ‖X (I k).1 ω‖ * ‖X (I k).2 ω‖) μ := by
     obtain rfl | hm := eq_or_ne m 0
-    · have : (fun ω : Ω ↦ ∏ k : Fin 0, ‖X (I k).1 ω‖ * ‖X (I k).2 ω‖) = fun _ => 1 := by
-        funext ω; simp
-      rw [this]
-      exact integrable_const 1
+    · simp
     simp_rw [Finset.prod_mul_distrib]
     rw [← memLp_one_iff_integrable]
-    have h1 : ∀ k ∈ (univ : Finset (Fin m)),
-        MemLp (fun ω => ‖X (I k).1 ω‖) (2 * (m : ℝ≥0∞)) μ := by
-      intro k _
-      have hk := Fintype.mem_piFinset.mp hI k
-      simp only [Finset.mem_product] at hk
-      exact (memLp_X _ hk.1).norm
-    have h2 : ∀ k ∈ (univ : Finset (Fin m)),
-        MemLp (fun ω => ‖X (I k).2 ω‖) (2 * (m : ℝ≥0∞)) μ := by
-      intro k _
-      have hk := Fintype.mem_piFinset.mp hI k
-      simp only [Finset.mem_product] at hk
-      exact (memLp_X _ hk.2).norm
-    have M1 := MemLp.prod' h1
-    have M2 := MemLp.prod' h2
-    have hm' : (m : ℝ≥0∞) ≠ 0 := by exact_mod_cast hm
-    have hmtop : (m : ℝ≥0∞) ≠ ⊤ := ENNReal.natCast_ne_top _
-    have heq2 : (∑ _k : Fin m, (2 * (m : ℝ≥0∞))⁻¹)⁻¹ = 2 := by
-      simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-      rw [ENNReal.mul_inv (Or.inl (by norm_num : (2:ℝ≥0∞) ≠ 0))
-          (Or.inl (by norm_num : (2:ℝ≥0∞) ≠ ⊤)),
-          mul_comm (2 : ℝ≥0∞)⁻¹, ← mul_assoc, ENNReal.mul_inv_cancel hm' hmtop,
-          one_mul, inv_inv]
-    rw [heq2] at M1 M2
-    have : ENNReal.HolderTriple (2 : ℝ≥0∞) 2 1 := ⟨by
-      rw [show (2 : ℝ≥0∞)⁻¹ + (2 : ℝ≥0∞)⁻¹ = 1 from ENNReal.inv_two_add_inv_two]
-      simp⟩
-    exact M2.mul' M1
+    have aux : (∑ _k : Fin m, (2 * (m : ℝ≥0∞))⁻¹)⁻¹ = 2 := by
+      rw [ENNReal.mul_inv (a := 2) (.inl <| by norm_num) (.inl <| by norm_num)]
+      simp [hm, mul_comm, ← mul_assoc, ENNReal.mul_inv_cancel]
+    refine .mul' (p := 2) (q := 2) ?_ ?_ <;>
+    · rw [← aux]
+      exact .prod' fun k _ ↦ (memLp_X _ <| by simp_all).norm
   have integrable_prod_inner_X I (hI : I ∈ A ×ˢ A ^^ m) :
     Integrable (fun ω ↦ ∏ k, inner ℝ (X (I k).1 ω) (X (I k).2 ω)) μ := sorry
   -- Call a family of indices `i₁, ..., iₙ, j₁, ..., jₙ` *even* if each `i ∈ A` appears an even

--- a/APAP/Prereqs/NewMarcinkiewiczZygmund.lean
+++ b/APAP/Prereqs/NewMarcinkiewiczZygmund.lean
@@ -56,7 +56,43 @@ theorem marcinkiewicz_zygmund_symmetric (iIndepFun_X : iIndepFun X μ)
   -- Turn the `L^p` assumption on the `X i` into various integrability conditions.
   have integrable_prod_norm_X I (hI : I ∈ A ×ˢ A ^^ m) :
     Integrable (fun ω ↦ ∏ k, ‖X (I k).1 ω‖ * ‖X (I k).2 ω‖) μ := by
-    sorry
+    by_cases hm : m = 0
+    · subst hm
+      have : (fun ω : Ω ↦ ∏ k : Fin 0, ‖X (I k).1 ω‖ * ‖X (I k).2 ω‖) = fun _ => 1 := by
+        funext ω; simp
+      rw [this]
+      exact integrable_const 1
+    rw [show (fun ω ↦ ∏ k : Fin m, ‖X (I k).1 ω‖ * ‖X (I k).2 ω‖)
+         = fun ω ↦ (∏ k : Fin m, ‖X (I k).1 ω‖) * (∏ k : Fin m, ‖X (I k).2 ω‖)
+       from funext fun _ => Finset.prod_mul_distrib]
+    rw [← memLp_one_iff_integrable]
+    have h1 : ∀ k ∈ (univ : Finset (Fin m)),
+        MemLp (fun ω => ‖X (I k).1 ω‖) (2 * (m : ℝ≥0∞)) μ := by
+      intro k _
+      have hk := Fintype.mem_piFinset.mp hI k
+      simp only [Finset.mem_product] at hk
+      exact (memLp_X _ hk.1).norm
+    have h2 : ∀ k ∈ (univ : Finset (Fin m)),
+        MemLp (fun ω => ‖X (I k).2 ω‖) (2 * (m : ℝ≥0∞)) μ := by
+      intro k _
+      have hk := Fintype.mem_piFinset.mp hI k
+      simp only [Finset.mem_product] at hk
+      exact (memLp_X _ hk.2).norm
+    have M1 := MemLp.prod' h1
+    have M2 := MemLp.prod' h2
+    have hm' : (m : ℝ≥0∞) ≠ 0 := by exact_mod_cast hm
+    have hmtop : (m : ℝ≥0∞) ≠ ⊤ := ENNReal.natCast_ne_top _
+    have heq2 : (∑ _k ∈ (univ : Finset (Fin m)), (2 * (m : ℝ≥0∞))⁻¹)⁻¹ = 2 := by
+      simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+      rw [ENNReal.mul_inv (Or.inl (by norm_num : (2:ℝ≥0∞) ≠ 0))
+          (Or.inl (by norm_num : (2:ℝ≥0∞) ≠ ⊤)),
+          mul_comm (2 : ℝ≥0∞)⁻¹, ← mul_assoc, ENNReal.mul_inv_cancel hm' hmtop,
+          one_mul, inv_inv]
+    rw [heq2] at M1 M2
+    haveI : ENNReal.HolderTriple (2 : ℝ≥0∞) 2 1 := ⟨by
+      rw [show (2 : ℝ≥0∞)⁻¹ + (2 : ℝ≥0∞)⁻¹ = 1 from ENNReal.inv_two_add_inv_two]
+      simp⟩
+    exact M2.mul' M1
   have integrable_prod_inner_X I (hI : I ∈ A ×ˢ A ^^ m) :
     Integrable (fun ω ↦ ∏ k, inner ℝ (X (I k).1 ω) (X (I k).2 ω)) μ := sorry
   -- Call a family of indices `i₁, ..., iₙ, j₁, ..., jₙ` *even* if each `i ∈ A` appears an even

--- a/APAP/Prereqs/NewMarcinkiewiczZygmund.lean
+++ b/APAP/Prereqs/NewMarcinkiewiczZygmund.lean
@@ -56,15 +56,12 @@ theorem marcinkiewicz_zygmund_symmetric (iIndepFun_X : iIndepFun X μ)
   -- Turn the `L^p` assumption on the `X i` into various integrability conditions.
   have integrable_prod_norm_X I (hI : I ∈ A ×ˢ A ^^ m) :
     Integrable (fun ω ↦ ∏ k, ‖X (I k).1 ω‖ * ‖X (I k).2 ω‖) μ := by
-    by_cases hm : m = 0
-    · subst hm
-      have : (fun ω : Ω ↦ ∏ k : Fin 0, ‖X (I k).1 ω‖ * ‖X (I k).2 ω‖) = fun _ => 1 := by
+    obtain rfl | hm := eq_or_ne m 0
+    · have : (fun ω : Ω ↦ ∏ k : Fin 0, ‖X (I k).1 ω‖ * ‖X (I k).2 ω‖) = fun _ => 1 := by
         funext ω; simp
       rw [this]
       exact integrable_const 1
-    rw [show (fun ω ↦ ∏ k : Fin m, ‖X (I k).1 ω‖ * ‖X (I k).2 ω‖)
-         = fun ω ↦ (∏ k : Fin m, ‖X (I k).1 ω‖) * (∏ k : Fin m, ‖X (I k).2 ω‖)
-       from funext fun _ => Finset.prod_mul_distrib]
+    simp_rw [Finset.prod_mul_distrib]
     rw [← memLp_one_iff_integrable]
     have h1 : ∀ k ∈ (univ : Finset (Fin m)),
         MemLp (fun ω => ‖X (I k).1 ω‖) (2 * (m : ℝ≥0∞)) μ := by
@@ -82,14 +79,14 @@ theorem marcinkiewicz_zygmund_symmetric (iIndepFun_X : iIndepFun X μ)
     have M2 := MemLp.prod' h2
     have hm' : (m : ℝ≥0∞) ≠ 0 := by exact_mod_cast hm
     have hmtop : (m : ℝ≥0∞) ≠ ⊤ := ENNReal.natCast_ne_top _
-    have heq2 : (∑ _k ∈ (univ : Finset (Fin m)), (2 * (m : ℝ≥0∞))⁻¹)⁻¹ = 2 := by
+    have heq2 : (∑ _k : Fin m, (2 * (m : ℝ≥0∞))⁻¹)⁻¹ = 2 := by
       simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
       rw [ENNReal.mul_inv (Or.inl (by norm_num : (2:ℝ≥0∞) ≠ 0))
           (Or.inl (by norm_num : (2:ℝ≥0∞) ≠ ⊤)),
           mul_comm (2 : ℝ≥0∞)⁻¹, ← mul_assoc, ENNReal.mul_inv_cancel hm' hmtop,
           one_mul, inv_inv]
     rw [heq2] at M1 M2
-    haveI : ENNReal.HolderTriple (2 : ℝ≥0∞) 2 1 := ⟨by
+    have : ENNReal.HolderTriple (2 : ℝ≥0∞) 2 1 := ⟨by
       rw [show (2 : ℝ≥0∞)⁻¹ + (2 : ℝ≥0∞)⁻¹ = 1 from ENNReal.inv_two_add_inv_two]
       simp⟩
     exact M2.mul' M1


### PR DESCRIPTION
This fills in selected sorries in finite-field, convolution, Hölder/Lp norm, weighted norm, and Marcinkiewicz-Zygmund prerequisite files.

The changes are limited to proof terms and small import adjustments needed by those proofs.

This PR does not attempt to make every touched file `sorry`-free. Some unrelated/pre-existing `sorry`s remain in:
- `APAP/FiniteField.lean`
- `APAP/Prereqs/LpNorm/Weighted.lean`
- `APAP/Prereqs/NewMarcinkiewiczZygmund.lean`

Note: These proofs were produced with assistance from a prototype agentic Lean proof-search system and then locally reviewed and verified.
