### PR TITLE
feat: monotonicity of weighted L^p norms in p

### DIFF
--- a/APAP/FiniteField.lean
+++ b/APAP/FiniteField.lean
@@ -346,7 +346,7 @@ lemma di_in_ff [DecidableEq G] [MeasurableSpace G] [DiscreteMeasurableSpace G] (
         gcongr
         · norm_num
         · positivity
-  have :=
+  have hp'q' : p' ≤ q' :=
     calc
       p' = 1 * ⌈(p' + 0 : ℝ)⌉₊ := by simp
       _ ≤ q' := by
@@ -363,7 +363,11 @@ lemma di_in_ff [DecidableEq G] [MeasurableSpace G] [DiscreteMeasurableSpace G] (
       1 + ε / 4 = 1 + ε / 2 / 2 := by ring
       _ ≤ ‖card G • (f ○ f) + 1‖_[p', μ univ] := unbalancing
       _ = card G • ‖(μ_[ℝ] A ○ μ A)‖_[p', μ univ] := by simp [this, wLpNorm_nsmul, -nsmul_eq_mul]
-      _ ≤ card G • ‖(μ_[ℝ] A ○ μ A)‖_[q', μ univ] := by gcongr
+      _ ≤ card G • ‖(μ_[ℝ] A ○ μ A)‖_[q', μ univ] := by
+        haveI : Nonempty G := ⟨hA₀.choose⟩
+        gcongr
+        exact wLpNorm_mono_right_of_sum_eq_one
+          (by exact_mod_cast sum_mu (R := ℝ≥0) univ_nonempty) (by exact_mod_cast hp'q') _
   let s' : Finset G := {x | 1 + ε / 8 ≤ card G • (μ A ○ μ A) x}
   have hss' : s q' (ε / 16) univ univ A ⊆ s' := by
     simp only [subset_iff, mem_s', ENNReal.coe_natCast, mu_univ_dconv_mu_univ,

--- a/APAP/FiniteField.lean
+++ b/APAP/FiniteField.lean
@@ -366,8 +366,8 @@ lemma di_in_ff [DecidableEq G] [MeasurableSpace G] [DiscreteMeasurableSpace G] (
       _ ≤ card G • ‖(μ_[ℝ] A ○ μ A)‖_[q', μ univ] := by
         haveI : Nonempty G := ⟨hA₀.choose⟩
         gcongr
-        exact wLpNorm_mono_right_of_sum_eq_one
-          (by exact_mod_cast sum_mu (R := ℝ≥0) univ_nonempty) (by exact_mod_cast hp'q') _
+        exact wLpNorm_mono_right
+          (mod_cast sum_mu (R := ℝ≥0) univ_nonempty) (mod_cast hp'q') _
   let s' : Finset G := {x | 1 + ε / 8 ≤ card G • (μ A ○ μ A) x}
   have hss' : s q' (ε / 16) univ univ A ⊆ s' := by
     simp only [subset_iff, mem_s', ENNReal.coe_natCast, mu_univ_dconv_mu_univ,

--- a/APAP/FiniteField.lean
+++ b/APAP/FiniteField.lean
@@ -364,7 +364,7 @@ lemma di_in_ff [DecidableEq G] [MeasurableSpace G] [DiscreteMeasurableSpace G] (
       _ ≤ ‖card G • (f ○ f) + 1‖_[p', μ univ] := unbalancing
       _ = card G • ‖(μ_[ℝ] A ○ μ A)‖_[p', μ univ] := by simp [this, wLpNorm_nsmul, -nsmul_eq_mul]
       _ ≤ card G • ‖(μ_[ℝ] A ○ μ A)‖_[q', μ univ] := by
-        haveI : Nonempty G := ⟨hA₀.choose⟩
+        have : Nonempty G := ⟨hA₀.choose⟩
         gcongr
         exact wLpNorm_mono_right
           (mod_cast sum_mu (R := ℝ≥0) univ_nonempty) (mod_cast hp'q') _

--- a/APAP/Physics/DRC.lean
+++ b/APAP/Physics/DRC.lean
@@ -266,11 +266,11 @@ lemma sifting_cor (hε : 0 < ε) (hε₁ : ε ≤ 1) (hδ : 0 < δ) (hp : Even p
       rw [nnratCast_dens, le_div_iff₀ (by positivity), ← mul_div_right_comm]
       have hμ_univ : ∑ x : G, ((μ univ x : ℝ≥0) : ℝ≥0∞) = 1 := by
         haveI : Nonempty G := ⟨hA.choose⟩
-        exact_mod_cast sum_mu (R := ℝ≥0) univ_nonempty
+        exact mod_cast sum_mu (R := ℝ≥0) univ_nonempty
       calc
         _ = (‖𝟭_[ℝ] A ○ 𝟭 A‖_[1, μ univ] : ℝ) := by
           simp [mu, wLpNorm_smul_right, dL1Norm_dconv, card_univ, inv_mul_eq_div]
-        _ ≤ _ := wLpNorm_mono_right_of_sum_eq_one hμ_univ (one_le_two.trans <| by norm_cast) _
+        _ ≤ _ := wLpNorm_mono_right hμ_univ (one_le_two.trans <| by norm_cast) _
     obtain ⟨A₁, -, A₂, -, h, hcard₁, hcard₂⟩ :=
       sifting univ univ hε hε₁ hδ hp hp₂ hpε (by simp) hA (by simpa)
     exact ⟨A₁, A₂, h, this.trans <| by simpa [nnratCast_dens] using hcard₁,

--- a/APAP/Physics/DRC.lean
+++ b/APAP/Physics/DRC.lean
@@ -264,10 +264,13 @@ lemma sifting_cor (hε : 0 < ε) (hε₁ : ε ≤ 1) (hδ : 0 < δ) (hp : Even p
       rw [mul_div_assoc, ← div_pow]
       gcongr
       rw [nnratCast_dens, le_div_iff₀ (by positivity), ← mul_div_right_comm]
+      have hμ_univ : ∑ x : G, ((μ univ x : ℝ≥0) : ℝ≥0∞) = 1 := by
+        haveI : Nonempty G := ⟨hA.choose⟩
+        exact_mod_cast sum_mu (R := ℝ≥0) univ_nonempty
       calc
         _ = (‖𝟭_[ℝ] A ○ 𝟭 A‖_[1, μ univ] : ℝ) := by
           simp [mu, wLpNorm_smul_right, dL1Norm_dconv, card_univ, inv_mul_eq_div]
-        _ ≤ _ := wLpNorm_mono_right (one_le_two.trans <| by norm_cast) _ _
+        _ ≤ _ := wLpNorm_mono_right_of_sum_eq_one hμ_univ (one_le_two.trans <| by norm_cast) _
     obtain ⟨A₁, -, A₂, -, h, hcard₁, hcard₂⟩ :=
       sifting univ univ hε hε₁ hδ hp hp₂ hpε (by simp) hA (by simpa)
     exact ⟨A₁, A₂, h, this.trans <| by simpa [nnratCast_dens] using hcard₁,

--- a/APAP/Physics/DRC.lean
+++ b/APAP/Physics/DRC.lean
@@ -264,9 +264,9 @@ lemma sifting_cor (hε : 0 < ε) (hε₁ : ε ≤ 1) (hδ : 0 < δ) (hp : Even p
       rw [mul_div_assoc, ← div_pow]
       gcongr
       rw [nnratCast_dens, le_div_iff₀ (by positivity), ← mul_div_right_comm]
-      have hμ_univ : ∑ x : G, ((μ univ x : ℝ≥0) : ℝ≥0∞) = 1 := by
-        haveI : Nonempty G := ⟨hA.choose⟩
-        exact mod_cast sum_mu (R := ℝ≥0) univ_nonempty
+      have : Nonempty G := ⟨hA.choose⟩
+      have hμ_univ : ∑ x : G, ((μ univ x : ℝ≥0) : ℝ≥0∞) = 1 :=
+        mod_cast sum_mu (R := ℝ≥0) univ_nonempty
       calc
         _ = (‖𝟭_[ℝ] A ○ 𝟭 A‖_[1, μ univ] : ℝ) := by
           simp [mu, wLpNorm_smul_right, dL1Norm_dconv, card_univ, inv_mul_eq_div]

--- a/APAP/Physics/Unbalancing.lean
+++ b/APAP/Physics/Unbalancing.lean
@@ -70,13 +70,13 @@ private lemma unbalancing'' (p : ℕ) (hp : 5 ≤ p) (hp₁ : Odd p) (hε₀ : 0
     (hε : ε ≤ ‖f‖_[p, ν]) :
     1 + ε / 2 ≤ ‖f + 1‖_[.ofReal (24 / ε * log (3 / ε) * p), ν] := by
   have hνprob : ∑ x, (ν x : ℝ≥0∞) = 1 := by
-    exact_mod_cast hν₁
+    exact mod_cast hν₁
   obtain hf₁ | hf₁ := le_total 2 ‖f + 1‖_[2 * p, ν]
   · calc
       1 + ε / 2 ≤ 1 + 1 / 2 := by grw [hε₁]
       _ ≤ 2 := by norm_num
       _ ≤ ‖f + 1‖_[2 * p, ν] := hf₁
-      _ ≤ _ := wLpNorm_mono_right_of_sum_eq_one hνprob ?_ _
+      _ ≤ _ := wLpNorm_mono_right hνprob ?_ _
     norm_cast
     rw [ENNReal.natCast_le_ofReal (by positivity)]
     push_cast
@@ -232,13 +232,13 @@ lemma unbalancing' (p : ℕ) (hp : p ≠ 0) (ε : ℝ) (hε₀ : 0 < ε) (hε₁
       _ ≤ 2 * (2 ^ 7 * ε⁻¹ * (2 ^ 2 * ε⁻¹) * p) := by gcongr <;> norm_num
       _ = 2 ^ 10 * ε⁻¹ ^ 2 * p := by ring
   have hνprob : ∑ x, (ν x : ℝ≥0∞) = 1 := by
-    exact_mod_cast hν₁
+    exact mod_cast hν₁
   calc
     1 + ε / 2 ≤ ↑‖f + 1‖_[.ofReal (24 / ε * log (3 / ε) * ↑(2 * p + 3)), ν] :=
       unbalancing'' (2 * p + 3) this ((even_two_mul _).add_odd <| by decide) hε₀ hε₁ hf hν hν₁ <|
-        hε.trans <| wLpNorm_mono_right_of_sum_eq_one hνprob
+        hε.trans <| wLpNorm_mono_right hνprob
           (Nat.cast_le.2 <| le_add_of_le_left <| le_mul_of_one_le_left' one_le_two) _
-    _ ≤ _ := wLpNorm_mono_right_of_sum_eq_one hνprob ?_ _
+    _ ≤ _ := wLpNorm_mono_right hνprob ?_ _
   norm_cast
   calc
     _ = 24 / ε * log (3 / ε) * ↑(2 * p + 3 * 1) := by simp

--- a/APAP/Physics/Unbalancing.lean
+++ b/APAP/Physics/Unbalancing.lean
@@ -69,12 +69,14 @@ private lemma unbalancing'' (p : ℕ) (hp : 5 ≤ p) (hp₁ : Odd p) (hε₀ : 0
     (hf : g ○ g = (↑) ∘ f) (hν : h ○ h = (↑) ∘ ν) (hν₁ : ∑ x, ν x = 1)
     (hε : ε ≤ ‖f‖_[p, ν]) :
     1 + ε / 2 ≤ ‖f + 1‖_[.ofReal (24 / ε * log (3 / ε) * p), ν] := by
+  have hνprob : ∑ x, (ν x : ℝ≥0∞) = 1 := by
+    exact_mod_cast hν₁
   obtain hf₁ | hf₁ := le_total 2 ‖f + 1‖_[2 * p, ν]
   · calc
       1 + ε / 2 ≤ 1 + 1 / 2 := by grw [hε₁]
       _ ≤ 2 := by norm_num
       _ ≤ ‖f + 1‖_[2 * p, ν] := hf₁
-      _ ≤ _ := wLpNorm_mono_right ?_ _ _
+      _ ≤ _ := wLpNorm_mono_right_of_sum_eq_one hνprob ?_ _
     norm_cast
     rw [ENNReal.natCast_le_ofReal (by positivity)]
     push_cast
@@ -229,12 +231,14 @@ lemma unbalancing' (p : ℕ) (hp : p ≠ 0) (ε : ℝ) (hε₀ : 0 < ε) (hε₁
       _ ≤ 2 * (120 * ε⁻¹ * (3 * ε⁻¹) * p) := by gcongr; exact Real.log_le_self (by positivity)
       _ ≤ 2 * (2 ^ 7 * ε⁻¹ * (2 ^ 2 * ε⁻¹) * p) := by gcongr <;> norm_num
       _ = 2 ^ 10 * ε⁻¹ ^ 2 * p := by ring
+  have hνprob : ∑ x, (ν x : ℝ≥0∞) = 1 := by
+    exact_mod_cast hν₁
   calc
     1 + ε / 2 ≤ ↑‖f + 1‖_[.ofReal (24 / ε * log (3 / ε) * ↑(2 * p + 3)), ν] :=
       unbalancing'' (2 * p + 3) this ((even_two_mul _).add_odd <| by decide) hε₀ hε₁ hf hν hν₁ <|
-        hε.trans <| wLpNorm_mono_right
-          (Nat.cast_le.2 <| le_add_of_le_left <| le_mul_of_one_le_left' one_le_two) _ _
-    _ ≤ _ := wLpNorm_mono_right ?_ _ _
+        hε.trans <| wLpNorm_mono_right_of_sum_eq_one hνprob
+          (Nat.cast_le.2 <| le_add_of_le_left <| le_mul_of_one_le_left' one_le_two) _
+    _ ≤ _ := wLpNorm_mono_right_of_sum_eq_one hνprob ?_ _
   norm_cast
   calc
     _ = 24 / ε * log (3 / ε) * ↑(2 * p + 3 * 1) := by simp

--- a/APAP/Physics/Unbalancing.lean
+++ b/APAP/Physics/Unbalancing.lean
@@ -69,8 +69,7 @@ private lemma unbalancing'' (p : ℕ) (hp : 5 ≤ p) (hp₁ : Odd p) (hε₀ : 0
     (hf : g ○ g = (↑) ∘ f) (hν : h ○ h = (↑) ∘ ν) (hν₁ : ∑ x, ν x = 1)
     (hε : ε ≤ ‖f‖_[p, ν]) :
     1 + ε / 2 ≤ ‖f + 1‖_[.ofReal (24 / ε * log (3 / ε) * p), ν] := by
-  have hνprob : ∑ x, (ν x : ℝ≥0∞) = 1 := by
-    exact mod_cast hν₁
+  have hνprob : ∑ x, (ν x : ℝ≥0∞) = 1 := mod_cast hν₁
   obtain hf₁ | hf₁ := le_total 2 ‖f + 1‖_[2 * p, ν]
   · calc
       1 + ε / 2 ≤ 1 + 1 / 2 := by grw [hε₁]
@@ -231,8 +230,7 @@ lemma unbalancing' (p : ℕ) (hp : p ≠ 0) (ε : ℝ) (hε₀ : 0 < ε) (hε₁
       _ ≤ 2 * (120 * ε⁻¹ * (3 * ε⁻¹) * p) := by gcongr; exact Real.log_le_self (by positivity)
       _ ≤ 2 * (2 ^ 7 * ε⁻¹ * (2 ^ 2 * ε⁻¹) * p) := by gcongr <;> norm_num
       _ = 2 ^ 10 * ε⁻¹ ^ 2 * p := by ring
-  have hνprob : ∑ x, (ν x : ℝ≥0∞) = 1 := by
-    exact mod_cast hν₁
+  have hνprob : ∑ x, (ν x : ℝ≥0∞) = 1 := mod_cast hν₁
   calc
     1 + ε / 2 ≤ ↑‖f + 1‖_[.ofReal (24 / ε * log (3 / ε) * ↑(2 * p + 3)), ν] :=
       unbalancing'' (2 * p + 3) this ((even_two_mul _).add_odd <| by decide) hε₀ hε₁ hf hν hν₁ <|

--- a/APAP/Prereqs/LpNorm/Weighted.lean
+++ b/APAP/Prereqs/LpNorm/Weighted.lean
@@ -103,11 +103,22 @@ lemma wLpNorm_pow_eq_sum_norm {p : ℕ} (hp : p ≠ 0) (w : α → ℝ≥0) (f :
 lemma wL1Norm_eq_sum_norm (w : α → ℝ≥0) (f : α → E) : ‖f‖_[1, w] = ∑ i, w i • ‖f i‖ := by
   simp [wLpNorm_eq_sum_norm]
 
-omit [Fintype α]
+/-- Monotonicity of weighted `L^p` norms in the exponent, for probability weights. -/
+lemma wLpNorm_mono_right_of_sum_eq_one
+    (hw : ∑ i, (w i : ℝ≥0∞) = 1) (hpq : p ≤ q) (f : α → E) :
+    ‖f‖_[p, w] ≤ ‖f‖_[q, w] := by
+  haveI : IsProbabilityMeasure (Measure.sum fun i ↦ (w i : ℝ≥0) • Measure.dirac (i : α)) := by
+    rw [isProbabilityMeasure_iff, Measure.sum_apply _ MeasurableSet.univ]
+    simp [hw, ENNReal.smul_def]
+  rw [wLpNorm, wLpNorm,
+      ← toReal_eLpNorm (μ := Measure.sum fun i ↦ (w i : ℝ≥0) • Measure.dirac i)
+        (MemLp.of_discrete (p := p)).aestronglyMeasurable,
+      ← toReal_eLpNorm (μ := Measure.sum fun i ↦ (w i : ℝ≥0) • Measure.dirac i)
+        (MemLp.of_discrete (p := q)).aestronglyMeasurable]
+  exact ENNReal.toReal_mono (MemLp.of_discrete (p := q)).eLpNorm_ne_top
+    (eLpNorm_le_eLpNorm_of_exponent_le hpq (MemLp.of_discrete (p := p)).aestronglyMeasurable)
 
-@[gcongr]
-lemma wLpNorm_mono_right (hpq : p ≤ q) (w : α → ℝ≥0) (f : α → E) : ‖f‖_[p, w] ≤ ‖f‖_[q, w] :=
-  sorry
+omit [Fintype α]
 
 section one_le
 

--- a/APAP/Prereqs/LpNorm/Weighted.lean
+++ b/APAP/Prereqs/LpNorm/Weighted.lean
@@ -104,7 +104,7 @@ lemma wL1Norm_eq_sum_norm (w : α → ℝ≥0) (f : α → E) : ‖f‖_[1, w] =
   simp [wLpNorm_eq_sum_norm]
 
 /-- Monotonicity of weighted `L^p` norms in the exponent, for probability weights. -/
-lemma wLpNorm_mono_right_of_sum_eq_one
+lemma wLpNorm_mono_right
     (hw : ∑ i, (w i : ℝ≥0∞) = 1) (hpq : p ≤ q) (f : α → E) :
     ‖f‖_[p, w] ≤ ‖f‖_[q, w] := by
   haveI : IsProbabilityMeasure (Measure.sum fun i ↦ (w i : ℝ≥0) • Measure.dirac (i : α)) := by

--- a/APAP/Prereqs/LpNorm/Weighted.lean
+++ b/APAP/Prereqs/LpNorm/Weighted.lean
@@ -107,7 +107,7 @@ lemma wL1Norm_eq_sum_norm (w : α → ℝ≥0) (f : α → E) : ‖f‖_[1, w] =
 lemma wLpNorm_mono_right
     (hw : ∑ i, (w i : ℝ≥0∞) = 1) (hpq : p ≤ q) (f : α → E) :
     ‖f‖_[p, w] ≤ ‖f‖_[q, w] := by
-  haveI : IsProbabilityMeasure (Measure.sum fun i ↦ (w i : ℝ≥0) • Measure.dirac (i : α)) := by
+  have : IsProbabilityMeasure (Measure.sum fun i ↦ (w i : ℝ≥0) • Measure.dirac (i : α)) := by
     rw [isProbabilityMeasure_iff, Measure.sum_apply _ MeasurableSet.univ]
     simp [hw, ENNReal.smul_def]
   rw [wLpNorm, wLpNorm,


### PR DESCRIPTION
Fill the `sorry` in `APAP/Prereqs/LpNorm/Weighted.lean` by proving the probability-weighted monotonicity lemma:

```lean
lemma wLpNorm_mono_right_of_sum_eq_one
```
The proof turns the weighted norm into an eLpNorm for the discrete probability measure associated to the weights, then applies monotonicity of eLpNorm in the exponent.

This also updates the existing uses in `APAP/Physics/DRC.lean`, `APAP/Physics/Unbalancing.lean`, and `APAP/FiniteField.lean`, where the relevant weights have total mass `1`.

Produced with assistance from a prototype agentic Lean proof-search system. Codex was used for review, refinement and simplification.